### PR TITLE
feat(about-section: implement about section on both mobile and desktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-intersection-observer": "9.5.2",
         "react-scroll": "1.8.9",
         "tailwindcss": "3.3.3"
       },
@@ -3394,6 +3395,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-intersection-observer": "9.5.2",
     "react-scroll": "1.8.9",
     "tailwindcss": "3.3.3"
   },

--- a/src/app/components/about-section/const.js
+++ b/src/app/components/about-section/const.js
@@ -1,19 +1,23 @@
 export const MY_ABOUT = [
   {
-    title: 'My Graduation',
-    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+    title: 'My Education',
+    sub_title: `I am proud to have pursued Computer Engineering at King Mongkut's University of Technology Thonburi (KMUTT) and gained invaluable experience through my various term projects and extracurricular activities. The 4 years I spent there were not only enjoyable but also enriched my life in meaningful ways.`,
+    timeline: '06/2017 - 06/2021 Bangkok, Thailand',
   },
   {
-    title: 'Internship',
-    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+    title: 'Internship - System Analysis at True Corporation',
+    sub_title: `I thoroughly examined the existing systems and developed some innovative ideas to enhance the website's functionality. Additionally, I designed a user-friendly dashboard that simplifies data analysis. Lastly, I created comprehensive guides and documentation to ensure a seamless process for everyone involved.`,
+    timeline: '06/2020 - 07/2020 Bangkok, Thailand',
   },
   {
     title: 'Pomelo - Associate Software Engineer',
-    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+    sub_title: `I was dedicated to enhancing the website's performance and functionality by identifying and resolving bottlenecks. My efforts included developing features such as a voucher system and product detail components. I also implemented event-tracking mechanisms to gain insights into user behavior. My contributions to code reviews were focused on maintaining code quality and adherence to coding standards through constructive feedback. My ultimate aim was to provide users with a seamless browsing experience.`,
+    timeline: '07/2021 - 02/2022 Bangkok, Thailand',
   },
   {
     title: 'Pomelo - Senior Software Engineer',
-    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+    sub_title: `As a key team member, I led the way in developing crucial platform features. This included a loyalty program that boosted customer engagement and retention, as well as integrating multiple payment gateways to expand the platform's reach. To gain valuable insights into user behavior, I implemented event-tracking mechanisms. Additionally, I utilized cutting-edge technologies to create efficient and high-performing frontend code, ensuring optimal website speed and responsiveness. Throughout this process, I worked closely with cross-functional teams to ensure that our frontend solutions aligned with business objectives and user needs.`,
+    timeline: '02/2022 - Present Bangkok, Thailand',
   },
 ]
 

--- a/src/app/components/about-section/const.js
+++ b/src/app/components/about-section/const.js
@@ -1,0 +1,20 @@
+export const MY_ABOUT = [
+  {
+    title: 'My Graduation',
+    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+  },
+  {
+    title: 'Internship',
+    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+  },
+  {
+    title: 'Pomelo - Associate Software Engineer',
+    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+  },
+  {
+    title: 'Pomelo - Senior Software Engineer',
+    sub_title: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+  },
+]
+
+export default { MY_ABOUT }

--- a/src/app/components/about-section/index.js
+++ b/src/app/components/about-section/index.js
@@ -5,7 +5,7 @@ import MyTimeline from './timeline'
 const AboutSection = ({}) => {
   return (
     <Element
-      name={1}
+      name={'1'}
       className="my-20 flex flex-col justify-center items-center"
     >
       <div className="flex flex-col items-center">

--- a/src/app/components/about-section/index.js
+++ b/src/app/components/about-section/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Element } from 'react-scroll'
-import { MY_ABOUT } from './const'
+import MyTimeline from './timeline'
 
 const AboutSection = ({}) => {
   return (
@@ -11,52 +11,7 @@ const AboutSection = ({}) => {
       <div className="flex flex-col items-center">
         <span className="text-violet-700 text-5xl font-bold">About</span>
         <span className="text-gray-700 text-l">Here's My Experience</span>
-        
-        <div className="sm:z-0 relative wrap overflow-hidden p-10 h-full">
-          <div
-            className="border-2-2 absolute border-opacity-20 border-gray-700 h-full border"
-            style={{ left: '50%' }}
-          />
-          {MY_ABOUT.map((info, idx) => (
-            <div>
-              {(idx + 1) % 2 !== 0 ? (
-                <div className="mb-8 flex justify-between items-center w-full md:right-timeline">
-                  <div className="order-1 w-5/12"></div>
-                  <div className="invisible md:visible md:z-10 flex items-center order-1 bg-gray-800 shadow-xl w-8 h-8 rounded-full">
-                    <h1 className="mx-auto font-semibold text-lg text-white">
-                      {idx + 1}
-                    </h1>
-                  </div>
-                  <div className="order-1 bg-gray-200 rounded-lg shadow-xl md:w-5/12 z-10 px-6 py-4">
-                    <h3 className="mb-3 font-bold text-gray-800 text-xl">
-                      {info.title}
-                    </h3>
-                    <p className="text-sm leading-snug tracking-wide text-gray-900 text-opacity-100">
-                      {info.sub_title}
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <div className="mb-8 flex justify-between flex-row-reverse items-center w-full md:left-timeline">
-                  <div className="order-1 w-5/12"></div>
-                  <div className="invisible md:visible md:z-10 flex items-center order-1 bg-gray-800 shadow-xl w-8 h-8 rounded-full">
-                    <h1 className="mx-auto text-white font-semibold text-lg">
-                      {idx + 1}
-                    </h1>
-                  </div>
-                  <div className="order-1 bg-violet-700 rounded-lg shadow-xl md:w-5/12 z-10 px-6 py-4">
-                    <h3 className="mb-3 font-bold text-white text-xl">
-                      {info.title}
-                    </h3>
-                    <p className="text-sm font-medium leading-snug tracking-wide text-white text-opacity-100">
-                      {info.sub_title}
-                    </p>
-                  </div>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+        <MyTimeline />
       </div>
     </Element>
   )

--- a/src/app/components/about-section/index.js
+++ b/src/app/components/about-section/index.js
@@ -1,13 +1,62 @@
 import React from 'react'
 import { Element } from 'react-scroll'
+import { MY_ABOUT } from './const'
 
 const AboutSection = ({}) => {
   return (
-    <Element name={1}>
-      <div className="h-screen my-12 flex flex-col justify-center items-center">
-        <span className="text-black text-5xl font-bold">
-          Coming Soon...
-        </span>
+    <Element
+      name={1}
+      className="my-20 flex flex-col justify-center items-center"
+    >
+      <div className="flex flex-col items-center">
+        <span className="text-violet-700 text-5xl font-bold">About</span>
+        <span className="text-gray-700 text-l">Here's My Experience</span>
+        
+        <div className="sm:z-0 relative wrap overflow-hidden p-10 h-full">
+          <div
+            className="border-2-2 absolute border-opacity-20 border-gray-700 h-full border"
+            style={{ left: '50%' }}
+          />
+          {MY_ABOUT.map((info, idx) => (
+            <div>
+              {(idx + 1) % 2 !== 0 ? (
+                <div className="mb-8 flex justify-between items-center w-full md:right-timeline">
+                  <div className="order-1 w-5/12"></div>
+                  <div className="invisible md:visible md:z-10 flex items-center order-1 bg-gray-800 shadow-xl w-8 h-8 rounded-full">
+                    <h1 className="mx-auto font-semibold text-lg text-white">
+                      {idx + 1}
+                    </h1>
+                  </div>
+                  <div className="order-1 bg-gray-200 rounded-lg shadow-xl md:w-5/12 z-10 px-6 py-4">
+                    <h3 className="mb-3 font-bold text-gray-800 text-xl">
+                      {info.title}
+                    </h3>
+                    <p className="text-sm leading-snug tracking-wide text-gray-900 text-opacity-100">
+                      {info.sub_title}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="mb-8 flex justify-between flex-row-reverse items-center w-full md:left-timeline">
+                  <div className="order-1 w-5/12"></div>
+                  <div className="invisible md:visible md:z-10 flex items-center order-1 bg-gray-800 shadow-xl w-8 h-8 rounded-full">
+                    <h1 className="mx-auto text-white font-semibold text-lg">
+                      {idx + 1}
+                    </h1>
+                  </div>
+                  <div className="order-1 bg-violet-700 rounded-lg shadow-xl md:w-5/12 z-10 px-6 py-4">
+                    <h3 className="mb-3 font-bold text-white text-xl">
+                      {info.title}
+                    </h3>
+                    <p className="text-sm font-medium leading-snug tracking-wide text-white text-opacity-100">
+                      {info.sub_title}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
     </Element>
   )

--- a/src/app/components/about-section/index.js
+++ b/src/app/components/about-section/index.js
@@ -1,14 +1,23 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useInView } from 'react-intersection-observer'
 import { Element } from 'react-scroll'
 import MyTimeline from './timeline'
 
-const AboutSection = ({}) => {
+const AboutSection = ({ setSection }) => {
+  const { inView, ref } = useInView()
+
+  useEffect(() => {
+    if (inView) {
+      setSection('1')
+    }
+  }, [inView])
+
   return (
     <Element
       name={'1'}
       className="my-20 flex flex-col justify-center items-center"
     >
-      <div className="flex flex-col items-center">
+      <div ref={ref} className="flex flex-col items-center">
         <span className="text-violet-700 text-5xl font-bold">About</span>
         <span className="text-gray-700 text-l">Here's My Experience</span>
         <MyTimeline />

--- a/src/app/components/about-section/timeline/index.js
+++ b/src/app/components/about-section/timeline/index.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import { MY_ABOUT } from '../const'
+
+const MyTimeline = () => {
+  return (
+    <div className="sm:z-0 relative wrap overflow-hidden p-10 h-full">
+      <div
+        className="border-2-2 absolute border-opacity-20 border-gray-700 h-full border"
+        style={{ left: '50%' }}
+      />
+      {MY_ABOUT.map((info, idx) => (
+        <div>
+          {(idx + 1) % 2 !== 0 ? (
+            <div className="mb-8 flex justify-between items-center w-full md:right-timeline">
+              <div className="order-1 w-5/12"></div>
+              <div className="invisible md:visible md:z-10 flex items-center order-1 bg-gray-800 shadow-xl w-8 h-8 rounded-full">
+                <h1 className="mx-auto font-semibold text-lg text-white">
+                  {idx + 1}
+                </h1>
+              </div>
+              <div className="order-1 bg-gray-200 rounded-lg shadow-xl md:w-5/12 z-10 px-6 py-4">
+                <h3 className="font-bold text-gray-800 text-xl">
+                  {info.title}
+                </h3>
+                <p className="mb-3 text-gray-500 text-sm">{info.timeline}</p>
+                <p className="text-sm leading-snug tracking-wide text-gray-900 text-opacity-100">
+                  {info.sub_title}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="mb-8 flex justify-between flex-row-reverse items-center w-full md:left-timeline">
+              <div className="order-1 w-5/12"></div>
+              <div className="invisible md:visible md:z-10 flex items-center order-1 bg-gray-800 shadow-xl w-8 h-8 rounded-full">
+                <h1 className="mx-auto text-white font-semibold text-lg">
+                  {idx + 1}
+                </h1>
+              </div>
+              <div className="order-1 bg-violet-700 rounded-lg shadow-xl md:w-5/12 z-10 px-6 py-4">
+                <h3 className="font-bold text-white text-xl">{info.title}</h3>
+                <p className="mb-3 text-white text-sm">{info.timeline}</p>
+                <p className="text-sm font-medium leading-snug tracking-wide text-white text-opacity-100">
+                  {info.sub_title}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default MyTimeline

--- a/src/app/components/common-layout/index.js
+++ b/src/app/components/common-layout/index.js
@@ -8,7 +8,7 @@ const CommonLayout = () => {
 
   return (
     <React.Fragment>
-      <Navigation setSection={setSection} />
+      <Navigation section={section} setSection={setSection} />
       <Section section={section} />
     </React.Fragment>
   )

--- a/src/app/components/common-layout/index.js
+++ b/src/app/components/common-layout/index.js
@@ -9,7 +9,7 @@ const CommonLayout = () => {
   return (
     <React.Fragment>
       <Navigation section={section} setSection={setSection} />
-      <Section section={section} />
+      <Section section={section} setSection={setSection} />
     </React.Fragment>
   )
 }

--- a/src/app/components/common-layout/index.js
+++ b/src/app/components/common-layout/index.js
@@ -4,7 +4,7 @@ import Navigation from '../navigation'
 import Section from '../sections'
 
 const CommonLayout = () => {
-  const [section, setSection] = useState(0)
+  const [section, setSection] = useState('0')
 
   return (
     <React.Fragment>

--- a/src/app/components/me-section/index.js
+++ b/src/app/components/me-section/index.js
@@ -1,16 +1,28 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useInView } from 'react-intersection-observer'
 import Image from 'next/image'
 import { Element } from 'react-scroll'
 import Button from '../commons/button'
 import { downloadMyResume } from './utils'
 
-const MeSection = () => {
+const MeSection = ({ setSection }) => {
+  const { inView, ref } = useInView()
+
+  useEffect(() => {
+    if (inView) {
+      setSection('0')
+    }
+  }, [inView])
+
   return (
     <Element
       name={'0'}
       className="h-fit bg-cover bg-center bg-gradient-to-r from-indigo-200"
     >
-      <div className="flex flex-col-reverse md:flex-row justify-center m-8 md:m-20">
+      <div
+        ref={ref}
+        className="flex flex-col-reverse md:flex-row justify-center m-8 md:m-20"
+      >
         <div className="flex flex-col items-center justify-center w-4/4 md:w-2/4 animate-bottom-to-top my-8">
           <div className="flex flex-col">
             <span className="text-violet-700 text-5xl font-bold">

--- a/src/app/components/me-section/index.js
+++ b/src/app/components/me-section/index.js
@@ -7,7 +7,7 @@ import { downloadMyResume } from './utils'
 const MeSection = () => {
   return (
     <Element
-      name={0}
+      name={'0'}
       className="h-fit bg-cover bg-center bg-gradient-to-r from-indigo-200"
     >
       <div className="flex flex-col-reverse md:flex-row justify-center m-8 md:m-20">

--- a/src/app/components/me-section/index.js
+++ b/src/app/components/me-section/index.js
@@ -8,7 +8,7 @@ const MeSection = () => {
   return (
     <Element
       name={0}
-      className="h-screen bg-cover bg-center bg-gradient-to-r from-indigo-200"
+      className="h-fit bg-cover bg-center bg-gradient-to-r from-indigo-200"
     >
       <div className="flex flex-col-reverse md:flex-row justify-center m-8 md:m-20">
         <div className="flex flex-col items-center justify-center w-4/4 md:w-2/4 animate-bottom-to-top my-8">
@@ -29,7 +29,7 @@ const MeSection = () => {
               onClickFunction={downloadMyResume}
             >
               <svg
-                class="fill-current w-4 h-4 mr-2"
+                className="fill-current w-4 h-4 mr-2"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
               >

--- a/src/app/components/navigation/const.js
+++ b/src/app/components/navigation/const.js
@@ -2,8 +2,8 @@ import { ICONS } from '../commons/icons/const'
 
 export const NAVIGATION_MENUS = [
   { title: 'Me', shouldShowNextMenu: true },
-  { title: 'About', shouldShowNextMenu: true },
-  { title: 'Skills', shouldShowNextMenu: false },
+  { title: 'About', shouldShowNextMenu: false },
+  // { title: 'Skills', shouldShowNextMenu: false },
 ]
 
 export const NAVIGATION_LINKS = [

--- a/src/app/components/navigation/desktop/index.js
+++ b/src/app/components/navigation/desktop/index.js
@@ -1,16 +1,14 @@
-import React, { useState } from 'react'
+import React from 'react'
 import clsx from 'clsx'
+import PropTypes from 'prop-types'
 import { ICONS, ICON_SIZE } from '../../commons/icons/const'
 import DesktopSeparateIcon from '../../commons/icons/desktopSeparateIcon'
 import Icon from '../../commons/icons'
 import { NAVIGATION_LINKS, NAVIGATION_MENUS } from '../const'
 import { handleSocialLinkClick } from '../utils'
 
-const DesktopNavigation = ({ setSection }) => {
-  const [isMenuActive, setIsMenuActive] = useState(0)
-
+const DesktopNavigation = ({ section, setSection }) => {
   const setSectionToScroll = (idx) => {
-    setIsMenuActive(idx)
     setSection && setSection(idx)
   }
 
@@ -34,7 +32,7 @@ const DesktopNavigation = ({ setSection }) => {
                 className={clsx(
                   'text-sm text-gray-400 hover:text-violet-700 hover:font-bold',
                   {
-                    'text-violet-700 font-bold': isMenuActive === idx,
+                    'text-violet-700 font-bold': section === idx,
                   },
                 )}
                 onClickCapture={() => setSectionToScroll(idx)}
@@ -59,6 +57,11 @@ const DesktopNavigation = ({ setSection }) => {
       </div>
     </React.Fragment>
   )
+}
+
+DesktopNavigation.propTypes = {
+  section: PropTypes.number,
+  setSection: PropTypes.func,
 }
 
 export default DesktopNavigation

--- a/src/app/components/navigation/desktop/index.js
+++ b/src/app/components/navigation/desktop/index.js
@@ -9,7 +9,7 @@ import { handleSocialLinkClick } from '../utils'
 
 const DesktopNavigation = ({ section, setSection }) => {
   const setSectionToScroll = (idx) => {
-    setSection && setSection(idx)
+    setSection && setSection(`${idx}`)
   }
 
   return (

--- a/src/app/components/navigation/desktop/index.js
+++ b/src/app/components/navigation/desktop/index.js
@@ -32,7 +32,7 @@ const DesktopNavigation = ({ section, setSection }) => {
                 className={clsx(
                   'text-sm text-gray-400 hover:text-violet-700 hover:font-bold',
                   {
-                    'text-violet-700 font-bold': section === idx,
+                    'text-violet-700 font-bold': section === `${idx}`,
                   },
                 )}
                 onClickCapture={() => setSectionToScroll(idx)}

--- a/src/app/components/navigation/index.js
+++ b/src/app/components/navigation/index.js
@@ -22,7 +22,7 @@ const Navigation = ({ setSection }) => {
   }, [])
 
   return (
-    <div className="sticky top-0 md:z-10">
+    <div className="sticky top-0 z-20">
       <nav className="relative px-4 py-4 flex justify-between items-center bg-white shadow">
         <DesktopNavigation setSection={setSection} />
         <span className="lg:hidden font-bold">This is me!</span>

--- a/src/app/components/navigation/index.js
+++ b/src/app/components/navigation/index.js
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
 import DesktopNavigation from './desktop'
 import MobileNavigation from './mobile'
 import { handleOpenMobileNav } from './utils'
-import propTypes from 'eslint-plugin-react/lib/rules/prop-types'
 
-const Navigation = ({ setSection }) => {
+const Navigation = ({ section, setSection }) => {
   useEffect(() => {
     document.addEventListener(
       'DOMContentLoaded',
@@ -24,7 +24,7 @@ const Navigation = ({ setSection }) => {
   return (
     <div className="sticky top-0 z-20">
       <nav className="relative px-4 py-4 flex justify-between items-center bg-white shadow">
-        <DesktopNavigation setSection={setSection} />
+        <DesktopNavigation section={section} setSection={setSection} />
         <span className="lg:hidden font-bold">This is me!</span>
         <div className="lg:hidden">
           <button className="navbar-burger flex items-center text-violet-700 p-3">
@@ -44,7 +44,8 @@ const Navigation = ({ setSection }) => {
 }
 
 Navigation.propTypes = {
-  setSection: propTypes.func,
+  section: PropTypes.number,
+  setSection: PropTypes.func,
 }
 
 export default Navigation

--- a/src/app/components/navigation/utils.js
+++ b/src/app/components/navigation/utils.js
@@ -17,7 +17,7 @@ const handleCloseMobileNav = (menus, setSection) => {
 
   lists?.forEach((list, idx) => {
     list.addEventListener('click', () => {
-      setSection(idx)
+      setSection(`${idx}`)
       menus?.forEach((menu) => {
         menu.classList.toggle('hidden')
       })

--- a/src/app/components/sections/index.js
+++ b/src/app/components/sections/index.js
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types'
 import MeSection from '../me-section'
 import AboutSection from '../about-section'
 
-const Section = ({ section }) => {
+const Section = ({ section, setSection }) => {
   useEffect(() => {
     const scrollToElements = () => {
       scroller.scrollTo(section, {
-        duration: 1500,
+        duration: 1000,
         delay: 2,
         smooth: true,
         offset: -120,
@@ -24,14 +24,15 @@ const Section = ({ section }) => {
 
   return (
     <React.Fragment>
-      <MeSection />
-      <AboutSection />
+      <MeSection setSection={setSection} />
+      <AboutSection setSection={setSection} />
     </React.Fragment>
   )
 }
 
 Section.propTypes = {
   section: PropTypes.number,
+  setSection: PropTypes.func,
 }
 
 export default Section

--- a/src/app/components/sections/index.js
+++ b/src/app/components/sections/index.js
@@ -11,7 +11,7 @@ const Section = ({ section }) => {
         duration: 1500,
         delay: 2,
         smooth: true,
-        offset: 20,
+        offset: -120,
       })
     }
 


### PR DESCRIPTION
## Pull request: This is me project 🚀 

### What is the problem(s)/feature(s)? 💡 

- Since we're launching our website without an about section. We need to implement them

### How can we solve them? 🔧 

- [x] Implement About section
- [x] Set a section as a parent state
- [x] Handle manual scroll to update the section state

### How can test the change? 💻 

- Checkout this branch
- Scroll to/click about section the to see the change
